### PR TITLE
Fixed the map-points appearing

### DIFF
--- a/Mappstruktur/js/functions.js
+++ b/Mappstruktur/js/functions.js
@@ -168,20 +168,18 @@ function importantBtn(theButton) {
 
 function displayLocations() {
     let locationArray = document.querySelectorAll(".locationPoint");
-    let prevLocation;
     locationArray.forEach(location => {
         let idNumber = location.id.substring(location.id.length - 1, location.id.length);
-
-
 
         if (location.id.length > 9) {
             idNumber = location.id.substring(location.id.length - 2, location.id.length);
         }
 
         if (idNumber > STATE.currentPhase) {
-            location.classList.toggle('none');
+            location.classList.add("none");
+        } else {
+            location.classList.remove("none");
         }
-
 
         location.addEventListener("click", function () {
             let prevSelected = document.querySelector(".markedLocation");
@@ -198,7 +196,6 @@ function displayLocations() {
             this.classList.toggle("markedLocation");
 
             sumText.innerHTML = summaries[idNumber - 1];
-
         });
     });
 }

--- a/Mappstruktur/php/functional_php/database.json
+++ b/Mappstruktur/php/functional_php/database.json
@@ -5,7 +5,7 @@
             "password": "1",
             "id": 0,
             "pronoun": "",
-            "storyPhase": 7,
+            "storyPhase": 9,
             "inventory": {
                 "mapItem": true,
                 "letterItem": false,
@@ -15,13 +15,13 @@
                     true,
                     true,
                     true,
-                    false,
-                    false
+                    true,
+                    true
                 ]
             },
             "hasPlayed": false,
-            "introDialogue": true,
-            "completedGame": true,
+            "introDialogue": false,
+            "completedGame": false,
             "outroDialogue": false
         },
         {

--- a/Mappstruktur/php/functional_php/dbBackup.json
+++ b/Mappstruktur/php/functional_php/dbBackup.json
@@ -5,7 +5,7 @@
             "password": "1",
             "id": 0,
             "pronoun": "",
-            "storyPhase": 7,
+            "storyPhase": 8,
             "inventory": {
                 "mapItem": true,
                 "letterItem": false,
@@ -15,14 +15,14 @@
                     true,
                     true,
                     true,
-                    false,
-                    false
+                    true,
+                    true
                 ]
             },
             "hasPlayed": false,
             "introDialogue": true,
-            "completedGame": false,
-            "outroDialogue": false
+            "completedGame": true,
+            "outroDialogue": true
         },
         {
             "username": "Sami",


### PR DESCRIPTION
Changed it so that the map-points doesn't all appear when you, for example, start a dialogue. Instead of toggling the none-class when the id-number is greater than the current phase it now instead adds the class when the id-number is greater and removes it when it is less than the current phase.