### PR TITLE
Piano css and map-points

### DIFF
--- a/Mappstruktur/css/pianoStyle.css
+++ b/Mappstruktur/css/pianoStyle.css
@@ -1,7 +1,6 @@
 #feedback {
     margin: 0px;
     padding: 0px;
-    font-size: 30px;
 }
 
 #keyboard {
@@ -19,17 +18,17 @@
 
 .whiteKey {
     height: 14.28%;
-    border-bottom: 3px solid black;
+    border-bottom: 3px solid var(--black);
     box-sizing: border-box;
     background-color: var(--white);
 }
 
 .whiteKey:active {
-    background-color: lightgray;
+    background-color: var(--gray);
 }
 
 .blackKey:active {
-    background-color: darkgrey;
+    background-color: var(--gray);
 }
 
 #B {
@@ -38,30 +37,35 @@
 
 .blackKey {
     z-index: 10;
-    background-color: black;
+    background-color: var(--black);
     height: 7.14%;
     position: absolute;
-    left: 40%;
+    left: 40.5%;
     width: 55%;
 }
 
 #feedback {
     width: 70%;
-    height: 40%;
+    height: 30%;
     flex-direction: column;
     justify-content: center;
     align-items: center;
-    background-color: white;
+    background-color: var(--white);
     z-index: 20;
     position: absolute;
     left: 15%;
     top: 30%;
     box-sizing: border-box;
+    text-align: center;
+    font-family: var(--elite);
 }
 
 #again {
     padding: 10px;
-    margin: 40px;
+    margin: 20px;
+    border: 1px solid var(--black);
+    background-color: var(--white);
+    font-family: var(--elite);
 }
 
 .hidden {
@@ -73,13 +77,11 @@
 }
 
 .good {
-    border: 5px solid green;
-    color: darkgreen;
+    border: 5px solid var(--green);
 }
 
 .bad {
-    border: 5px solid red;
-    color: darkred;
+    border: 5px solid var(--red);
 }
 
 /* 3.57*/

--- a/Mappstruktur/js/gameElements.js
+++ b/Mappstruktur/js/gameElements.js
@@ -16,8 +16,8 @@ const pianoString =
         '<div class="whiteKey" id="B"></div>' +
         '<div class="hidden" id="feedback">' +
             '<p id="feedbackText"></p>' +
-            '<button id="again">Go again!</button>' +
-            '<p>Notes by</p>' +
+            '<button id="again">Försök igen</button>' +
+            '<p>Not-ljud av</p>' +
             '<a href="https://freesound.org/people/ion_/">ion_</a>' +
         '</div>' +
     '</div>' +

--- a/Mappstruktur/js/gameScripts/pianoScript.js
+++ b/Mappstruktur/js/gameScripts/pianoScript.js
@@ -43,16 +43,21 @@ function arrayCheck() {
         if(result) {
             feedback.classList.remove('hidden');
             feedback.classList.add('good', 'visible');
-            feedbackText.innerText = 'Good job!';
+            feedbackText.innerText = 'Bra jobbat! Prova att gå tilbaka till dialogfönstret.';
             patchState("currentUser", "completedGame", true);
             dialogueInit("outro");
 
+            // Minor CSS-changes
+            again.style.display = "none";
+            feedbackText.style.marginBottom = "20px";
+
+            // make the interactive-button not keep blinking
             let gameBtn = document.getElementById("interactiveBtn");
             gameBtn.classList.remove("important");
         } else {
             feedback.classList.remove('hidden');
             feedback.classList.add('bad', 'visible');
-            feedbackText.innerText = 'Bad job!';
+            feedbackText.innerText = 'Det lät inte rätt... Prova en gång till.';
         }
     }
 }

--- a/Mappstruktur/php/functional_php/database.json
+++ b/Mappstruktur/php/functional_php/database.json
@@ -5,7 +5,7 @@
             "password": "1",
             "id": 0,
             "pronoun": "",
-            "storyPhase": 9,
+            "storyPhase": 4,
             "inventory": {
                 "mapItem": true,
                 "letterItem": false,
@@ -21,7 +21,7 @@
             },
             "hasPlayed": false,
             "introDialogue": false,
-            "completedGame": false,
+            "completedGame": true,
             "outroDialogue": false
         },
         {

--- a/Mappstruktur/php/functional_php/dbBackup.json
+++ b/Mappstruktur/php/functional_php/dbBackup.json
@@ -5,7 +5,7 @@
             "password": "1",
             "id": 0,
             "pronoun": "",
-            "storyPhase": 8,
+            "storyPhase": 4,
             "inventory": {
                 "mapItem": true,
                 "letterItem": false,
@@ -20,9 +20,9 @@
                 ]
             },
             "hasPlayed": false,
-            "introDialogue": true,
-            "completedGame": true,
-            "outroDialogue": true
+            "introDialogue": false,
+            "completedGame": false,
+            "outroDialogue": false
         },
         {
             "username": "Sami",

--- a/Mappstruktur/php/page_php/map.php
+++ b/Mappstruktur/php/page_php/map.php
@@ -742,16 +742,16 @@
                 style="fill:none;stroke:#131116;stroke-linecap:round;stroke-linejoin:round;stroke-width:0.5173653135790346px" />
             <line x1="220.83" y1="12.01" x2="235.41" y2="9.71"
                 style="fill:none;stroke:#131116;stroke-linecap:round;stroke-linejoin:round;stroke-width:0.5173653135790346px" />
-            <circle class="locationPoint pelarna" id="location7" cx="222.81" cy="365.04" r="10.11"/>
-            <circle class="locationPoint zodiac" id="location6" cx="295.99" cy="313.35" r="10.11"/>
-            <circle class="locationPoint gubben" id="location5" cx="338.23" cy="179.45" r="10.11"/>
-            <circle class="locationPoint elves" id="location8" cx="206.92" cy="199.39" r="10.11"/>
-            <circle class="locationPoint ormhuve" id="location9" cx="145.3" cy="163.06" r="10.11"/>
-            <circle class="locationPoint kajak" id="location10" cx="22.68" cy="155.52" r="10.11"/>
-            <circle class="locationPoint orkestern" id="location4" cx="261.31" cy="125.05" r="10.11"/>
-            <circle class="locationPoint teatern" id="location3" cx="285.18" cy="119.02" r="10.11"/>
-            <circle class="locationPoint apPojke" id="location2" cx="255.54" cy="104.59" r="10.11"/>
-            <circle class="locationPoint inblick" id="location1" cx="218.3" cy="31.69" r="10.11"/>
+            <circle class="locationPoint pelarna none" id="location7" cx="222.81" cy="365.04" r="10.11"/>
+            <circle class="locationPoint zodiac none" id="location6" cx="295.99" cy="313.35" r="10.11"/>
+            <circle class="locationPoint gubben none" id="location5" cx="338.23" cy="179.45" r="10.11"/>
+            <circle class="locationPoint elves none" id="location8" cx="206.92" cy="199.39" r="10.11"/>
+            <circle class="locationPoint ormhuve none" id="location9" cx="145.3" cy="163.06" r="10.11"/>
+            <circle class="locationPoint kajak none" id="location10" cx="22.68" cy="155.52" r="10.11"/>
+            <circle class="locationPoint orkestern none" id="location4" cx="261.31" cy="125.05" r="10.11"/>
+            <circle class="locationPoint teatern none" id="location3" cx="285.18" cy="119.02" r="10.11"/>
+            <circle class="locationPoint apPojke none" id="location2" cx="255.54" cy="104.59" r="10.11"/>
+            <circle class="locationPoint inblick none" id="location1" cx="218.3" cy="31.69" r="10.11"/>
         </svg>
     </div>
     <div id="infoSection">


### PR DESCRIPTION
Changed the css and text of the piano game's game over screens so that they are more in line with the graphic profile. I also fixed the problem with the map points being visible for a split second when loading the page by making all of them have display: none at initialization.